### PR TITLE
Feat: Add support for already succeeded purchase status

### DIFF
--- a/paymentclient/src/main/java/ir/net_box/paymentclient/payment/Payment.kt
+++ b/paymentclient/src/main/java/ir/net_box/paymentclient/payment/Payment.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import ir.net_box.paymentclient.callback.ConnectionCallback
 import ir.net_box.paymentclient.connection.Connection
 import ir.net_box.paymentclient.connection.PaymentConnection
+import ir.net_box.paymentclient.util.isAlreadySucceeded
 import ir.net_box.paymentclient.util.isFailed
 import ir.net_box.paymentclient.util.isSucceed
 import ir.net_box.paymentclient.util.useBroadCastForPaymentCallbacks
@@ -47,6 +48,9 @@ class Payment(private val context: Context, private val packageName: String) {
             purchaseProduct.isSucceed() -> {
                 purchaseCallback.purchaseSucceed?.let { it(purchaseProduct) }
             }
+            purchaseProduct.isAlreadySucceeded() -> {
+                purchaseCallback.purchaseIsAlreadySucceeded?.let { it(purchaseProduct) }
+            }
             purchaseProduct.isFailed() -> {
                 purchaseCallback.purchaseFailed?.invoke(
                     Throwable("Purchase is failed!"), purchaseProduct
@@ -58,6 +62,9 @@ class Payment(private val context: Context, private val packageName: String) {
                         when {
                             intent.isSucceed() -> {
                                 purchaseCallback.purchaseSucceed?.let { it(purchaseProduct) }
+                            }
+                            intent.isAlreadySucceeded() -> {
+                                purchaseCallback.purchaseIsAlreadySucceeded?.let { it(purchaseProduct) }
                             }
                             intent.isFailed() -> {
                                 purchaseCallback.purchaseFailed?.invoke(

--- a/paymentclient/src/main/java/ir/net_box/paymentclient/payment/PurchaseCallback.kt
+++ b/paymentclient/src/main/java/ir/net_box/paymentclient/payment/PurchaseCallback.kt
@@ -6,10 +6,18 @@ class PurchaseCallback {
 
     internal var purchaseSucceed: ((bundle: Bundle) -> Unit)? = null
 
+    internal var purchaseIsAlreadySucceeded: ((bundle: Bundle) -> Unit)? = null
+
     internal var purchaseFailed: ((throwable: Throwable, bundle: Bundle) -> Unit)? = null
 
     fun purchaseSucceed(block: (Bundle) -> Unit) {
         purchaseSucceed = { bundle ->
+            block(bundle)
+        }
+    }
+
+    fun purchaseIsAlreadySucceeded(block: (Bundle) -> Unit) {
+        purchaseIsAlreadySucceeded = { bundle ->
             block(bundle)
         }
     }

--- a/paymentclient/src/main/java/ir/net_box/paymentclient/util/PaymentBundle.kt
+++ b/paymentclient/src/main/java/ir/net_box/paymentclient/util/PaymentBundle.kt
@@ -28,6 +28,11 @@ fun Bundle.isSucceed() =
         NETBOX_PAYMENT_RESULT, ServiceResultStatus.UNKNOWN.statusCode
     ) == ServiceResultStatus.SUCCEED.statusCode
 
+fun Bundle.isAlreadySucceeded() =
+    getInt(
+        NETBOX_PAYMENT_RESULT, ServiceResultStatus.UNKNOWN.statusCode
+    ) == ServiceResultStatus.ALREADY_SUCCEEDED.statusCode
+
 fun Bundle.isFailed() =
     getInt(
         NETBOX_PAYMENT_RESULT,
@@ -39,6 +44,11 @@ fun Intent.isSucceed() =
         NETBOX_PAYMENT_RESULT,
         ServiceResultStatus.UNKNOWN.statusCode
     ) == ServiceResultStatus.SUCCEED.statusCode
+
+fun Intent.isAlreadySucceeded() =
+    getIntExtra(
+        NETBOX_PAYMENT_RESULT, ServiceResultStatus.UNKNOWN.statusCode
+    ) == ServiceResultStatus.ALREADY_SUCCEEDED.statusCode
 
 fun Intent.isFailed() =
     getIntExtra(

--- a/paymentclient/src/main/java/ir/net_box/paymentclient/util/ServiceResultStatus.kt
+++ b/paymentclient/src/main/java/ir/net_box/paymentclient/util/ServiceResultStatus.kt
@@ -3,5 +3,6 @@ package ir.net_box.paymentclient.util
 enum class ServiceResultStatus(val statusCode: Int) {
     SUCCEED(1),
     FAILED(2),
-    UNKNOWN(3)
+    UNKNOWN(3),
+    ALREADY_SUCCEEDED(4),
 }


### PR DESCRIPTION
- Introduce `ALREADY_SUCCEEDED` status in `ServiceResultStatus`.
- Add `purchaseIsAlreadySucceeded` callback to `PurchaseCallback`.
- Add `isAlreadySucceeded` extension functions for `Bundle` and `Intent`.
- Handle `ALREADY_SUCCEEDED` status in `Payment` and call the `purchaseIsAlreadySucceeded` callback.