### PR TITLE
Fix: Handle broadcast receiver flags and service binding for Android 13+

### DIFF
--- a/paymentclient/src/main/java/ir/net_box/paymentclient/payment/Payment.kt
+++ b/paymentclient/src/main/java/ir/net_box/paymentclient/payment/Payment.kt
@@ -10,6 +10,7 @@ import ir.net_box.paymentclient.callback.ConnectionCallback
 import ir.net_box.paymentclient.connection.Connection
 import ir.net_box.paymentclient.connection.PaymentConnection
 import ir.net_box.paymentclient.util.isAlreadySucceeded
+import ir.net_box.paymentclient.util.isAndroid13OrHigher
 import ir.net_box.paymentclient.util.isFailed
 import ir.net_box.paymentclient.util.isSucceed
 import ir.net_box.paymentclient.util.useBroadCastForPaymentCallbacks
@@ -73,10 +74,18 @@ class Payment(private val context: Context, private val packageName: String) {
                             }
                         }
                     }
-                    context.registerReceiver(
-                        resultBroadcastReceiver,
-                        IntentFilter(PAYMENT_BROADCAST_ACTION)
-                    )
+                    if (isAndroid13OrHigher) {
+                        context.registerReceiver(
+                            resultBroadcastReceiver,
+                            IntentFilter(PAYMENT_BROADCAST_ACTION),
+                            Context.RECEIVER_EXPORTED
+                        )
+                    } else {
+                        context.registerReceiver(
+                            resultBroadcastReceiver,
+                            IntentFilter(PAYMENT_BROADCAST_ACTION)
+                        )
+                    }
                     isReceiverRegistered = true
                 } else {
                     purchaseCallback.purchaseFailed?.invoke(

--- a/paymentclient/src/main/java/ir/net_box/paymentclient/util/Config.kt
+++ b/paymentclient/src/main/java/ir/net_box/paymentclient/util/Config.kt
@@ -1,0 +1,4 @@
+package ir.net_box.paymentclient.util
+
+val isAndroid13OrHigher =
+    android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU


### PR DESCRIPTION
- Introduce `isAndroid13OrHigher` to check the OS version.
- Use `Context.RECEIVER_EXPORTED` flag for registering broadcast receivers on Android 13+.
- Avoid binding to the service on Android 13+ and start activity directly.
- Fallback to intent for starting activity in case of SecurityException.